### PR TITLE
Fixed aws-format-instance-string name field.

### DIFF
--- a/helm-aws.el
+++ b/helm-aws.el
@@ -73,7 +73,8 @@
   "Constructs a human-friendly string of a server instance - showing name, IP and launch date"
   (let* ((ip (plist-get instance :PrivateIpAddress))
          (tags (plist-get instance :Tags))
-         (name (plist-get (elt (cl-remove-if-not #'(lambda (tag) (string= (plist-get tag :Key) "Name")) tags) 0) :Value))
+         (nameTag (cl-remove-if-not #'(lambda (tag) (string= (plist-get tag :Key) "Name")) tags))
+         (name (if (= (length nameTag) 1) (plist-get (elt nameTag 0) :Value) ip))
          (launch-time (plist-get instance :LaunchTime))
          (launch-date (car (split-string launch-time "T"))))
     (concat name " - " ip " - " launch-date)))

--- a/helm-aws.el
+++ b/helm-aws.el
@@ -69,6 +69,14 @@
          (code (plist-get state :Code)))
     (eq code 16)))
 
+(defun aws-ellipsify (str len)
+  "Truncate STR at LEN chars then add right padded spaces up to LEN + 3 (for the ellipsis)"
+  (let* ((truncated (if (> (length str) len) (concat (substring str 0 len) "...") str))
+         (new-len (format "%d" (+ len 3)))
+         (formatter-str (concat "%-" new-len "s"))
+         (block-str (format formatter-str truncated)))
+    block-str))
+
 (defun aws-format-instance-string (instance)
   "Constructs a human-friendly string of a server instance - showing name, IP and launch date"
   (let* ((ip (plist-get instance :PrivateIpAddress))
@@ -77,7 +85,7 @@
          (name (if (= (length nameTag) 1) (plist-get (elt nameTag 0) :Value) ip))
          (launch-time (plist-get instance :LaunchTime))
          (launch-date (car (split-string launch-time "T"))))
-    (concat name " - " ip " - " launch-date)))
+    (concat (aws-ellipsify name 30) " - " (format "%15s" ip) " - " launch-date)))
 
 (defun aws-get-ip-from-instance-string (instance-str)
   "extracts IP address back from constructed string"

--- a/helm-aws.el
+++ b/helm-aws.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/istib/helm-aws
 ;; Version: 20141205.1
 ;; X-Original-Version: 0.2
-;; Package-Requires: ((helm "1.5.3"))
+;; Package-Requires: ((helm "1.5.3")(cl-lib "0.5"))
 ;; Keywords:
 
 ;; This file is not part of GNU Emacs
@@ -36,6 +36,7 @@
 
 ;;; Code:
 (require 'json)
+(require 'cl-lib)
 
 (defvar aws-user-account
   "ubuntu"
@@ -71,8 +72,8 @@
 (defun aws-format-instance-string (instance)
   "Constructs a human-friendly string of a server instance - showing name, IP and launch date"
   (let* ((ip (plist-get instance :PrivateIpAddress))
-         (tags (elt (plist-get instance :Tags) 0))
-         (name (plist-get tags :Value))
+         (tags (plist-get instance :Tags))
+         (name (plist-get (elt (cl-remove-if-not #'(lambda (tag) (string= (plist-get tag :Key) "Name")) tags) 0) :Value))
          (launch-time (plist-get instance :LaunchTime))
          (launch-date (car (split-string launch-time "T"))))
     (concat name " - " ip " - " launch-date)))

--- a/helm-aws.el
+++ b/helm-aws.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/istib/helm-aws
 ;; Version: 20141205.1
 ;; X-Original-Version: 0.2
-;; Package-Requires: ((helm "1.5.3")(cl-lib "0.5"))
+;; Package-Requires: ((helm "1.5.3")(cl-lib "0.5")(s "1.9.0"))
 ;; Keywords:
 
 ;; This file is not part of GNU Emacs
@@ -37,6 +37,7 @@
 ;;; Code:
 (require 'json)
 (require 'cl-lib)
+(require 's)
 
 (defvar aws-user-account
   "ubuntu"
@@ -69,14 +70,6 @@
          (code (plist-get state :Code)))
     (eq code 16)))
 
-(defun aws-ellipsify (str len)
-  "Truncate STR at LEN chars then add right padded spaces up to LEN + 3 (for the ellipsis)"
-  (let* ((truncated (if (> (length str) len) (concat (substring str 0 len) "...") str))
-         (new-len (format "%d" (+ len 3)))
-         (formatter-str (concat "%-" new-len "s"))
-         (block-str (format formatter-str truncated)))
-    block-str))
-
 (defun aws-format-instance-string (instance)
   "Constructs a human-friendly string of a server instance - showing name, IP and launch date"
   (let* ((ip (plist-get instance :PrivateIpAddress))
@@ -85,7 +78,7 @@
          (name (if (= (length nameTag) 1) (plist-get (elt nameTag 0) :Value) ip))
          (launch-time (plist-get instance :LaunchTime))
          (launch-date (car (split-string launch-time "T"))))
-    (concat (aws-ellipsify name 30) " - " (format "%15s" ip) " - " launch-date)))
+    (concat (format "%-30s" (s-truncate 30 name)) " - " (format "%15s" ip) " - " launch-date)))
 
 (defun aws-get-ip-from-instance-string (instance-str)
   "extracts IP address back from constructed string"

--- a/helm-aws.el
+++ b/helm-aws.el
@@ -133,7 +133,7 @@ Argument INSTANCE-JSON is the json behind the row of helm data."
       (erase-buffer)
       (delete-other-windows)
       (insert json)
-      (beginning-of-buffer)
+      (goto-char (point-min))
       (set-buffer-modified-p nil)
       (view-mode)
       (message "Press q to quit."))))


### PR DESCRIPTION
Previously the name field was populated by getting the first
 tag.  This doesn't work if your host has multiple tags.

So I refactored it to use cl-lib to filter the first
 Name tag.