### PR TITLE
Pass actual list of candidates to helm

### DIFF
--- a/helm-aws.el
+++ b/helm-aws.el
@@ -188,8 +188,8 @@ If it is stopped, start it.  If it is running, stop it."
   (let ((choices (aws-get-active-instances)))
     (helm
      :buffer "*helm-aws*"
-     :sources '((name . "EC2 Instances")
-                (candidates . choices)
+     :sources `((name . "EC2 Instances")
+                (candidates . ,choices)
                 (action . (("SSH" .
                             (lambda (instance-json)
                               (aws-ssh-into-instance (aws-get-ip-from-instance instance-json))))


### PR DESCRIPTION
* `helm-aws.el` (`helm-aws`): Unquote `choices` in order to pass `helm` its value instead of the symbol (which may be useless when resuming the session).

Before the change in this PR, the following steps caused an error message:

1. Invoke `helm-aws`.
2. Exit the Helm session.
3. Invoke another Helm session; e.g., `helm-M-x`.
4. Resume the `helm-aws` session via `C-u M-x helm-resume`.
5. Type some new input or delete some previous input in order to make Helm update the candidates.

Instead of updating the candidates, Helm would print this error:

    Error running timer: (error "In ‘EC2 Instances’ source: ‘choices’ \n (error \"helm-interpret-value: Symbol must be a function or a variable\")")

After the change in this PR, the resume `helm-aws` session updates its candidates properly.

BTW, it would be easy to convert `helm-aws` to use `helm-build-sync-source`, which seems to be the new and recommended way to provide Helm with sources.  I don't know that it would offer much advantage, but I would be happy to make a PR to do so if desired.